### PR TITLE
Card sorting and wish blacklists

### DIFF
--- a/NGUInjector/AllocationProfiles/RebirthStuff/BaseRebirth.cs
+++ b/NGUInjector/AllocationProfiles/RebirthStuff/BaseRebirth.cs
@@ -428,6 +428,14 @@ namespace NGUInjector.AllocationProfiles.RebirthStuff
                     }
                 }
             }
+
+
+            if (rebirth)
+            {
+                // Use whatever blood we have left on blood number before rebirthing
+                Main.Log("Casting number blood spell before rebirth");
+                CharObj.bloodSpells.castRebirthSpell();
+            }
         }
     }
 }

--- a/NGUInjector/Main.cs
+++ b/NGUInjector/Main.cs
@@ -257,6 +257,7 @@ namespace NGUInjector
                         ActivateFruits = false,
                         ManageR3 = true,
                         WishPriorities = new int[] { },
+                        WishBlacklist = new int[] { },
                         BeastMode = true,
                         ManageNGUDiff = true,
                         AllocationFile = "default",
@@ -287,6 +288,8 @@ namespace NGUInjector
                         TrashAdventureCards = false,
                         AutoCastCards = false,
                         CardsTrashQuality = 0,
+                        CardSortOrder = new string[0],
+                        CardSortEnabled = false,
                         TrashCardCost = 0,
                         DontCastCardType = new string[0],
                         TrashChunkers = false,
@@ -850,7 +853,10 @@ namespace NGUInjector
                 {
                     _cardManager.CastCards();
                 }
-
+                if (Settings.CardSortEnabled && Settings.CardSortOrder.Length > 0)
+                {
+                    _cardManager.SortCards();
+                }
                 if (Settings.ManageCooking)
                 {
                     _cookingManager.manageFood();

--- a/NGUInjector/Managers/CardManager.cs
+++ b/NGUInjector/Managers/CardManager.cs
@@ -181,5 +181,68 @@ namespace NGUInjector.Managers
                 }
             }
         }
+    
+        public void SortCards()
+        {
+            try
+            {
+                Main.Log($"Sorting Cards by priorities: {Main.Settings.CardSortOrder.ToString()}");
+                _character.cards.cards.Sort(CompareCards);
+                for(var i = 0; i < _character.cards.cards.Count; i++)
+                {
+                    _cardsController.updateDeckCard(i);
+                }
+            }
+            catch (Exception e)
+            {
+                Main.Log(e.Message);
+                Main.Log(e.StackTrace);
+            }
+        }
+
+        private int CompareByPriority(string priority, Card c1, Card c2)
+        {
+            if (priority.ToUpper() == "RARITY")
+            {
+                return c2.cardRarity.CompareTo(c1.cardRarity);
+            }
+
+            if (priority.ToUpper() == "TIER")
+            {
+                return c2.tier.CompareTo(c1.tier);
+            }
+
+            if (priority.ToUpper() == "COST")
+            {
+                return c2.manaCosts.Sum().CompareTo(c1.manaCosts.Sum());
+            }
+
+            if (priority.StartsWith("TYPE:")) {
+                var bonusType = priority.Substring(5);
+
+                if (c1.bonusType.ToString() == bonusType && c2.bonusType.ToString() == bonusType)
+                    return 0;
+                else if (c2.bonusType.ToString() == bonusType)
+                    return 1;
+                else if (c1.bonusType.ToString() == bonusType)
+                    return -1;
+                else
+                    return 0;
+            }
+
+            return 0;
+        }
+
+        private int CompareCards(Card c1, Card c2)
+        {
+            foreach(var priority in Main.Settings.CardSortOrder)
+            {
+                var index = CompareByPriority(priority, c1, c2);
+
+                if(index != 0) return index;
+            }
+
+            return 0;
+        }
     }
 }

--- a/NGUInjector/Managers/WishManager.cs
+++ b/NGUInjector/Managers/WishManager.cs
@@ -93,6 +93,10 @@ namespace NGUInjector.Managers
             {
                 return false;
             }
+            if(Settings.WishBlacklist.Length > 0 && Settings.WishBlacklist.Contains(wishId))
+            {
+                return false;
+            }
             return true;          
         }
 

--- a/NGUInjector/SavedSettings.cs
+++ b/NGUInjector/SavedSettings.cs
@@ -68,6 +68,7 @@ namespace NGUInjector
         [SerializeField] private bool _manageR3;
         [SerializeField] private bool _activateFruits;
         [SerializeField] private int[] _wishPriorities;
+        [SerializeField] private int[] _wishBlacklist;
         [SerializeField] private bool _wishSortPriorities;
         [SerializeField] private bool _wishSortOrder;
         [SerializeField] private bool _beastMode;
@@ -99,6 +100,8 @@ namespace NGUInjector
         [SerializeField] private bool _autoCastCards;
         [SerializeField] private int _autoCastCardType;
         [SerializeField] private bool _trashAdventureCards;
+        [SerializeField] private string[] _cardSortOrder;
+        [SerializeField] private bool _cardSortEnabled;
         [SerializeField] private int _trashCardCost;
         [SerializeField] private string[] _dontCastCardType;
         [SerializeField] private bool _trashChunkers;
@@ -232,6 +235,7 @@ namespace NGUInjector
             _manageR3 = other.ManageR3;
             _activateFruits = other.ActivateFruits;
             _wishPriorities = other.WishPriorities;
+            _wishBlacklist = other.WishBlacklist;
             _wishSortPriorities = other.WishSortPriorities;
             _wishSortOrder = other.WishSortOrder;
             _beastMode = other.BeastMode;
@@ -280,6 +284,8 @@ namespace NGUInjector
             _trashAdventureCards = other._trashAdventureCards;
             _trashCardCost = other._trashCardCost;
             _dontCastCardType = other._dontCastCardType;
+            _cardSortOrder = other._cardSortOrder;
+            _cardSortEnabled = other._cardSortEnabled;
             _trashChunkers = other._trashChunkers;
             _hackAdvance = other.HackAdvance;
             _manageCooking = other._manageCooking;
@@ -875,6 +881,16 @@ namespace NGUInjector
                 SaveSettings();
             }
         }
+        public int[] WishBlacklist
+        {
+            get => _wishBlacklist;
+            set
+            {
+                if (value == _wishBlacklist) return;
+                _wishBlacklist = value;
+                SaveSettings();
+            }
+        }
 
         public bool WishSortPriorities
         {
@@ -1225,6 +1241,26 @@ namespace NGUInjector
             {
                 if (value == _dontCastCardType) return;
                 _dontCastCardType = value;
+                SaveSettings();
+            }
+        }
+        public string[] CardSortOrder
+        {
+            get => _cardSortOrder;
+            set
+            {
+                if (value == _cardSortOrder) return;
+                _cardSortOrder = value;
+                SaveSettings();
+            }
+        }
+        public bool CardSortEnabled
+        {
+            get => _cardSortEnabled;
+            set
+            {
+                if (value == _cardSortEnabled) return;
+                _cardSortEnabled = value;
                 SaveSettings();
             }
         }


### PR DESCRIPTION
(Apologies, these should really be seperate PRs, but I CBA to split them locally).

## Wish blacklists

Added a new option in settings.json called "_wishBlacklist" which you can give a list of wish IDs that will never be run. I often find it's easier to list the ones you don't want and let the default sorting figure out the rest.

## Card sorting

Added new new options in settings.json:

**_cardSortEnabled**: Set to true to enable automated card sorting. (**false** by default).

**_cardSortOrder**: Array of priorities to sort by. The cards will first be sorted by the first priority, and if multiple cards match the first priority then they will be sorted by the second, and so on.
  Supports these options:

- **RARITY**: Sort by the card rarity ("Good"/"Okay", etc.)
- **COST**: Sort by the total mayo cost.
- **TIER**: Sort  by the card tier
- **TYPE:xxxx** Replace 'xxxx' with a specific card bonus type, i.e. one of:  "energyNGUSpeed", "magicNGUSpeed", "wandoosSpeed", "augSpeed", "TMSpeed", "hackSpeed", "wishSpeed", "atkDefStats", "adventureStat", "dropChance", "goldDrop", "dayCareSpeed", "PP", "QP".

### Example
In settings.json: 
```
"_cardSortEnabled": true,
"_cardSortOrder": [
        "RARITY",
        "TYPE:adventureStat",
        "TYPE:hackSpeed",
        "COST"
    ],
```
This will first order all the cards by rarity. For any that have the same rarity, it will prioritise adv. stat cards, then hack speed cards, then for any others (as well as adv. and wish cards with the same rarity) it will order them by cost.